### PR TITLE
Update MLSelectPhotoPickerAssetsViewController.m

### DIFF
--- a/MLSelectPhoto/Classes/ViewControllers/MLSelectPhotoPickerAssetsViewController.m
+++ b/MLSelectPhoto/Classes/ViewControllers/MLSelectPhotoPickerAssetsViewController.m
@@ -254,7 +254,11 @@ static NSString *const _identifier = @"toolBarThumbCollectionViewCell";
     _maxCount = maxCount;
     
     if (!_privateTempMaxCount) {
-        _privateTempMaxCount = maxCount;
+          if (maxCount) {
+            _privateTempMaxCount = maxCount;
+        }else{
+            _privateTempMaxCount = KPhotoShowMaxCount;
+        }
     }
     
     if (self.selectAssets.count == maxCount){


### PR DESCRIPTION
在选9张照片后，取消一个再选中，出现判断已经选满